### PR TITLE
Fixed the incompatibility of DjangoWhiteNoise

### DIFF
--- a/home/wsgi/prod.py
+++ b/home/wsgi/prod.py
@@ -1,9 +1,9 @@
 import os
 
 from django.core.wsgi import get_wsgi_application
-from whitenoise.django import DjangoWhiteNoise
+from whitenoise import WhiteNoise
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "home.settings.prod")
 
 application = get_wsgi_application()
-application = DjangoWhiteNoise(application)
+application = WhiteNoise(application)


### PR DESCRIPTION
using WhiteNoise rather than DjangoWhiteNoise from whitenoise rather than whitemoise.django is more compatible as sometimes DjangoWhiteNoise  gives errors while deploying on heroku